### PR TITLE
Add Time Window for Emcee Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Each role is assigned randomly while considering only from the eligible persons 
     - They are preaching within the next 2 Sundays
     - They were assigned to that role within the last 4 weeks
     - They are teaching the youth the same week
-- A person can't be assigned to a Sunday School Teacher role for 2 consecutive weeks to allow for rotation among team
+- To allow for better rotation among the team, a person can't be assigned a certain role if they've been assigned to it recently:
+    - Sunday School Teacher - within the last 4 weeks
+    - Emcee - within the last 2 weeks
 
 **NOTE:** There could be additional custom conditions.
 

--- a/schedule_builder/models/person.py
+++ b/schedule_builder/models/person.py
@@ -20,6 +20,13 @@ class Person:
         assigned_dates (List[date]): The dates when the person has been assigned to an event.
         last_assigned_dates (dict): A dictionary mapping each role to the last date the person was assigned to that role.
 
+    Class-Level Constants:
+        WORSHIP_LEADER_ROLE_TIME_WINDOW (timedelta): Time window for assigning a worship leader role (default: 4 weeks).
+        SUNDAY_SCHOOL_TEACHER_ROLE_TIME_WINDOW (timedelta): Time window for assigning a Sunday school teacher role (default: 4 weeks).
+        EMCEE_ROLE_TIME_WINDOW (timedelta): Time window for assigning an emcee role (default: 2 weeks).
+        PREACHING_TIME_WINDOW (timedelta): Time window for assigning a preaching role (default: 1 week).
+        CONSECUTIVE_ASSIGNMENTS_LIMIT (int): Limit for consecutive assigned event dates (default: 3).
+
     Methods:
         assign_event(date): Assigns the person to an event on the given date.
         get_next_preaching_date(reference_date): Returns the next preaching date after the given reference date.
@@ -27,6 +34,11 @@ class Person:
         is_unavailable_due_to_preaching(reference_date): Checks if the person is unavailable due to an upcoming preaching date.
         assigned_too_many_times_recently(reference_date): Checks if the person has been assigned too many times recently.
     """
+    WORSHIP_LEADER_ROLE_TIME_WINDOW = timedelta(weeks=4)
+    SUNDAY_SCHOOL_TEACHER_ROLE_TIME_WINDOW = timedelta(weeks=4)
+    EMCEE_ROLE_TIME_WINDOW = timedelta(weeks=2)
+    PREACHING_TIME_WINDOW = timedelta(weeks=1)
+    CONSECUTIVE_ASSIGNMENTS_LIMIT = 3
 
     def __init__(
         self,
@@ -56,15 +68,6 @@ class Person:
         self.on_leave = on_leave
         self.assigned_dates: List[date] = []
         self.last_assigned_dates = {role: None for role in roles}
-
-        # Time windows
-        self.worship_leader_role_time_window = timedelta(weeks=4)
-        self.sunday_school_teacher_role_time_window = timedelta(weeks=4)
-        self.emcee_role_time_window = timedelta(weeks=2)
-        self.preaching_time_window = timedelta(weeks=1)
-
-        # Limit for consecutive assigned event dates
-        self.consecutive_assignments_limit = 3
 
     def assign_event(self, date: date, role: Role) -> None:
         """
@@ -113,17 +116,17 @@ class Person:
         if role == Role.WORSHIPLEADER:
             return (
                 self.last_assigned_dates[role] is None
-                or date - self.last_assigned_dates[role] > self.worship_leader_role_time_window
+                or date - self.last_assigned_dates[role] > Person.WORSHIP_LEADER_ROLE_TIME_WINDOW
             )
         elif role == Role.SUNDAYSCHOOLTEACHER:
             return (
                 self.last_assigned_dates[role] is None
-                or date - self.last_assigned_dates[role] > self.sunday_school_teacher_role_time_window
+                or date - self.last_assigned_dates[role] > Person.SUNDAY_SCHOOL_TEACHER_ROLE_TIME_WINDOW
             )
         elif role == Role.EMCEE:
             return (
                 self.last_assigned_dates[role] is None
-                or date - self.last_assigned_dates[role] > self.emcee_role_time_window
+                or date - self.last_assigned_dates[role] > Person.EMCEE_ROLE_TIME_WINDOW
             )
         return True
 
@@ -142,7 +145,7 @@ class Person:
 
         # Unavailable if date is too close to next preaching date based on time window
         next_date = self.get_next_preaching_date(reference_date)
-        if next_date and next_date - reference_date <= self.preaching_time_window:
+        if next_date and next_date - reference_date <= Person.PREACHING_TIME_WINDOW:
             return True
 
         return False
@@ -161,11 +164,11 @@ class Person:
             return False
 
         # Check if total assigned/preaching dates is less than the limit
-        if (len(self.assigned_dates or []) + len(self.preaching_dates or []) < self.consecutive_assignments_limit):
+        if (len(self.assigned_dates or []) + len(self.preaching_dates or []) < Person.CONSECUTIVE_ASSIGNMENTS_LIMIT):
             return False
 
         # Calculate the past date outside of the consecutive assignment limit
-        past_reference_date = reference_date - timedelta(weeks=self.consecutive_assignments_limit)
+        past_reference_date = reference_date - timedelta(weeks=Person.CONSECUTIVE_ASSIGNMENTS_LIMIT)
 
         # Count dates assigned within past time window
         all_dates = set(self.assigned_dates + self.preaching_dates)
@@ -173,7 +176,7 @@ class Person:
             1 for date in all_dates if past_reference_date <= date <= reference_date
         )
 
-        return dates_between_count >= self.consecutive_assignments_limit
+        return dates_between_count >= Person.CONSECUTIVE_ASSIGNMENTS_LIMIT
 
     def __str__(self) -> str:
         """

--- a/schedule_builder/models/person.py
+++ b/schedule_builder/models/person.py
@@ -60,6 +60,7 @@ class Person:
         # Time windows
         self.worship_leader_role_time_window = timedelta(weeks=4)
         self.sunday_school_teacher_role_time_window = timedelta(weeks=4)
+        self.emcee_role_time_window = timedelta(weeks=2)
         self.preaching_time_window = timedelta(weeks=1)
 
         # Limit for consecutive assigned event dates
@@ -118,6 +119,11 @@ class Person:
             return (
                 self.last_assigned_dates[role] is None
                 or date - self.last_assigned_dates[role] > self.sunday_school_teacher_role_time_window
+            )
+        elif role == Role.EMCEE:
+            return (
+                self.last_assigned_dates[role] is None
+                or date - self.last_assigned_dates[role] > self.emcee_role_time_window
             )
         return True
 

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -101,7 +101,7 @@ def test_was_not_assigned_too_recently_to_role():
     reference_date = date(2024, 7, 7)
     role = Role.ACOUSTIC
     person = Person(name='TestName',
-                    roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
+                    roles=[Role.WORSHIPLEADER, role, Role.LYRICS],
                     blockout_dates=[],
                     preaching_dates=[],
                     on_leave=False)
@@ -118,7 +118,7 @@ def test_was_not_assigned_too_recently_to_role_with_no_assignments():
     reference_date = date(2024, 6, 30)
     role = Role.WORSHIPLEADER
     person = Person(name='TestName',
-                    roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
+                    roles=[role, Role.ACOUSTIC, Role.LYRICS],
                     blockout_dates=[],
                     preaching_dates=[],
                     on_leave=False)
@@ -135,7 +135,7 @@ def test_was_not_assigned_too_recently_to_role_worship_leader_4_weeks_ago():
     reference_date = date(2025, 4, 5)
     role = Role.WORSHIPLEADER
     person = Person(name='TestName',
-                    roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
+                    roles=[role],
                     blockout_dates=[],
                     preaching_dates=[],
                     on_leave=False)
@@ -153,7 +153,7 @@ def test_was_not_assigned_too_recently_to_role_worship_leader_over_4_weeks_ago()
     reference_date = date(2025, 4, 5)
     role = Role.WORSHIPLEADER
     person = Person(name='TestName',
-                    roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
+                    roles=[role],
                     blockout_dates=[],
                     preaching_dates=[],
                     on_leave=False)
@@ -171,7 +171,7 @@ def test_was_not_assigned_too_recently_to_role_sunday_school_teacher_4_weeks_ago
     reference_date = date(2024, 7, 28)
     role = Role.SUNDAYSCHOOLTEACHER
     person = Person(name='TestName',
-                    roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
+                    roles=[role],
                     blockout_dates=[],
                     preaching_dates=[],
                     on_leave=False)
@@ -189,7 +189,43 @@ def test_was_not_assigned_too_recently_to_role_sunday_school_teacher_over_4_week
     reference_date = date(2024, 8, 4)
     role = Role.SUNDAYSCHOOLTEACHER
     person = Person(name='TestName',
-                    roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
+                    roles=[role],
+                    blockout_dates=[],
+                    preaching_dates=[],
+                    on_leave=False)
+    
+    # Act
+    person.assign_event(date=last_assigned_date, role=role)
+    not_assigned_recently = person.was_not_assigned_too_recently_to_role(role=role, date=reference_date)
+
+    # Assert
+    assert not_assigned_recently == True
+
+def test_was_not_assigned_too_recently_to_role_emcee_2_weeks_ago():
+    # Arrange
+    last_assigned_date = date(2025, 3, 23)
+    reference_date = date(2025, 4, 6)
+    role = Role.EMCEE
+    person = Person(name='TestName',
+                    roles=[role],
+                    blockout_dates=[],
+                    preaching_dates=[],
+                    on_leave=False)
+    
+    # Act
+    person.assign_event(date=last_assigned_date, role=role)
+    not_assigned_recently = person.was_not_assigned_too_recently_to_role(role=role, date=reference_date)
+
+    # Assert
+    assert not_assigned_recently == False
+
+def test_was_not_assigned_too_recently_to_role_emcee_over_2_weeks_ago():
+    # Arrange
+    last_assigned_date = date(2025, 3, 16)
+    reference_date = date(2025, 4, 6)
+    role = Role.EMCEE
+    person = Person(name='TestName',
+                    roles=[role],
                     blockout_dates=[],
                     preaching_dates=[],
                     on_leave=False)


### PR DESCRIPTION
- Add a time window of 2 weeks for Emcee role to allow for better rotation among the team
- Add Person.was_not_assigned_too_recently_to_role tests for 2 week threshold for Emcee role
- Move Person time windows and limit constants to class level attributes