### PR TITLE
Refactor App Class and Convert Person and Preacher to Data Classes

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -23,7 +23,7 @@ def create_app(
         team (List[Person]): A list of team members.
         preachers (List[Preacher]): A list of preachers.
         rotation (List[str]): A list of worship leader names.
-        title (str): The title of the app, defaulting to "Schedule Builder".
+        title (str): The title of the app.
 
     Returns:
         App: A fully initialized App instance.

--- a/app_factory.py
+++ b/app_factory.py
@@ -1,0 +1,56 @@
+# Standard Library Imports
+from typing import List
+
+# Local Imports
+from schedule_builder.helpers.file_exporter import FileExporter
+from schedule_builder.models.person import Person
+from schedule_builder.models.preacher import Preacher
+from ui.application import App
+from ui.ui_manager import UIManager
+from ui.ui_schedule_handler import UIScheduleHandler
+
+
+def create_app(
+    team: List[Person],
+    preachers: List[Preacher],
+    rotation: List[str],
+    title: str,
+) -> App:
+    """
+    Factory method to create and configure the app instance with the necessary dependencies.
+
+    Args:
+        team (List[Person]): A list of team members.
+        preachers (List[Preacher]): A list of preachers.
+        rotation (List[str]): A list of worship leader names.
+        title (str): The title of the app, defaulting to "Schedule Builder".
+
+    Returns:
+        App: A fully initialized App instance.
+    """
+    file_exporter = FileExporter()
+    schedule_handler = UIScheduleHandler(
+        team=team,
+        preachers=preachers,
+        rotation=rotation,
+        file_exporter=file_exporter,
+    )
+
+    # Create UIManager without app reference initially
+    ui_manager = UIManager(
+        app=None,
+        schedule_handler=schedule_handler,
+        title=title,
+    )
+
+    # Create App
+    app = App(
+        file_exporter=file_exporter,
+        schedule_handler=schedule_handler,
+        ui_manager=ui_manager,
+    )
+
+    # Inject the App reference into UIManager
+    ui_manager.app = app
+
+    return app

--- a/main.py
+++ b/main.py
@@ -3,17 +3,14 @@ import logging
 import os
 
 # Local Imports
+from app_factory import create_app
 from config import OUTPUT_FOLDER_PATH, LOG_FILE_PATH
 from schedule_builder.builders.team_initializer import TeamInitializer
-from ui.application import App
 
 
 def set_logging() -> None:
     """
     Configures logging settings for the application.
-
-    Sets up logging to write messages of level INFO or higher to the specified log file.
-    The log file is overwritten each time the application starts.
     """
     logging.basicConfig(
         filename=LOG_FILE_PATH,
@@ -26,14 +23,6 @@ def set_logging() -> None:
 def main() -> None:
     """
     Main entry point of the application.
-
-    This function performs the following:
-    - Creates the output directory if it does not exist.
-    - Configures logging settings for the application.
-    - Initializes team data (team, preachers, rotation).
-    - Starts the application GUI using the initialized data.
-
-    The function runs the main loop of the application once initialization is complete.
     """
     # Setup output directory and logging config
     os.makedirs(OUTPUT_FOLDER_PATH, exist_ok=True)
@@ -44,8 +33,10 @@ def main() -> None:
     team, preachers, rotation = team_initializer.initialize_team()
 
     # Run application
-    app = App(team=team, preachers=preachers, rotation=rotation)
-    app.mainloop()
+    app = create_app(
+        team=team, preachers=preachers, rotation=rotation, title="Schedule Builder"
+    )
+    app.start()
 
 
 if __name__ == "__main__":

--- a/schedule_builder/models/person.py
+++ b/schedule_builder/models/person.py
@@ -1,4 +1,5 @@
 # Standard Library Imports
+from dataclasses import dataclass, field
 from datetime import date
 from typing import List, Optional
 
@@ -6,34 +7,32 @@ from typing import List, Optional
 from ..models.role import Role
 
 
+@dataclass
 class Person:
     """
     A class to represent a person and their associated roles and availability information.
     """
 
-    def __init__(
-        self,
-        name: str,
-        roles: List[Role],
-        blockout_dates: Optional[List[date]] = None,
-        preaching_dates: Optional[List[date]] = None,
-        teaching_dates: Optional[List[date]] = None,
-        on_leave: bool = False,
-    ):
+    name: str
+    roles: List[Role]
+    blockout_dates: List[date] = field(default_factory=list)
+    preaching_dates: List[date] = field(default_factory=list)
+    teaching_dates: List[date] = field(default_factory=list)
+    on_leave: bool = False
+
+    assigned_dates: List[date] = field(default_factory=list, init=False)
+    last_assigned_dates: dict = field(default_factory=dict, init=False)
+    role_assigned_dates: dict = field(default_factory=dict, init=False)
+
+    def __post_init__(self):
         """
-        Initializes the Person with a name, roles, and optionally blockout dates, preaching dates, teaching dates, and leave status.
+        Initializes the `last_assigned_dates` and `role_assigned_dates` attributes.
+
+        `last_assigned_dates` is a dictionary mapping roles to `None`, and
+        `role_assigned_dates` is a dictionary mapping roles to empty lists.
         """
-        self.name: str = name
-        self.roles: List[Role] = roles
-        self.blockout_dates: List[date] = blockout_dates if blockout_dates else []
-        self.preaching_dates: List[date] = preaching_dates if preaching_dates else []
-        self.teaching_dates: List[date] = teaching_dates if teaching_dates else []
-        self.on_leave = on_leave
-        self.assigned_dates: List[date] = []
-        self.last_assigned_dates: dict[Role, Optional[date]] = {
-            role: None for role in roles
-        }
-        self.role_assigned_dates: dict[Role, List[date]] = {role: [] for role in roles}
+        self.last_assigned_dates = {role: None for role in self.roles}
+        self.role_assigned_dates = {role: [] for role in self.roles}
 
     def assign_event(self, event_date: date, role: Role) -> None:
         """

--- a/schedule_builder/models/preacher.py
+++ b/schedule_builder/models/preacher.py
@@ -1,33 +1,21 @@
+from dataclasses import dataclass, field
 from datetime import date
-from typing import List, Optional
+from typing import List
 
 
+@dataclass
 class Preacher:
     """
     A class to represent a preacher and their associated information.
     """
 
-    def __init__(
-        self, name: str, graphics_support: str, dates: Optional[List[date]] = None
-    ):
-        """
-        Initializes the Preacher with a name, graphics support, and optionally a list of preaching dates.
-
-        Args:
-            name (str): The name of the preacher.
-            graphics_support (str): The graphics support person or team associated with the preacher.
-            dates (List[date], optional): A list of dates when the preacher is scheduled to preach. Defaults to an empty list.
-        """
-        self.name: str = name
-        self.graphics_support: str = graphics_support
-        self.dates: List[date] = dates if dates else []
+    name: str
+    graphics_support: str
+    dates: List[date] = field(default_factory=list)
 
     def __str__(self) -> str:
         """
         Returns a string representation of the Preacher, including their name, graphics support, and preaching dates.
-
-        Returns:
-            str: A formatted string representing the preacher's details (name, graphics support, and preaching dates).
         """
         preaching_dates_str = ", ".join(
             [date.strftime("%B-%d-%Y") for date in self.dates]

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+from schedule_builder.models.person import Person
+from schedule_builder.models.preacher import Preacher
+from app_factory import create_app
+
+
+@patch("app_factory.FileExporter")
+@patch("app_factory.UIScheduleHandler")
+@patch("app_factory.UIManager")
+@patch("app_factory.App")
+@patch("customtkinter.CTk.__init__", return_value=None)
+def test_create_app_wires_dependencies_correctly(
+    mock_ctk,
+    mock_app_class,
+    mock_ui_manager_class,
+    mock_schedule_handler_class,
+    mock_file_exporter_class,
+):
+    # Arrange
+    team = [MagicMock(spec=Person)]
+    preachers = [MagicMock(spec=Preacher)]
+    rotation = ["TestName"]
+    title = "Test"
+
+    mock_file_exporter = MagicMock()
+    mock_file_exporter_class.return_value = mock_file_exporter
+
+    mock_schedule_handler = MagicMock()
+    mock_schedule_handler_class.return_value = mock_schedule_handler
+
+    mock_ui_manager = MagicMock()
+    mock_ui_manager_class.return_value = mock_ui_manager
+
+    mock_app_instance = MagicMock()
+    mock_app_class.return_value = mock_app_instance
+
+    # Act
+    app = create_app(team=team, preachers=preachers, rotation=rotation, title=title)
+
+    # Assert
+    mock_file_exporter_class.assert_called_once()
+    mock_schedule_handler_class.assert_called_once_with(
+        team=team,
+        preachers=preachers,
+        rotation=rotation,
+        file_exporter=mock_file_exporter,
+    )
+    mock_ui_manager_class.assert_called_once_with(
+        app=None,
+        schedule_handler=mock_schedule_handler,
+        title=title,
+    )
+    mock_app_class.assert_called_once_with(
+        file_exporter=mock_file_exporter,
+        schedule_handler=mock_schedule_handler,
+        ui_manager=mock_ui_manager,
+    )
+
+    assert mock_ui_manager.app == mock_app_instance
+    assert app == mock_app_instance

--- a/tests/test_person.py
+++ b/tests/test_person.py
@@ -37,15 +37,34 @@ def test_assign_event():
     assert date_two in person.role_assigned_dates[role_two]
 
 
-@pytest.mark.parametrize("p_dates", [None, []])
-def test_get_next_preaching_date_with_no_dates(p_dates):
+@pytest.mark.parametrize(
+    "reference_date, preaching_dates, expected",
+    [
+        (date(2024, 7, 7), [], None),  # No dates
+        (
+            date(2024, 7, 7),
+            [date(2024, 6, 30), date(2024, 7, 7), date(2024, 7, 14)],
+            date(2024, 7, 7),
+        ),  # Same Date
+        (
+            date(2024, 7, 21),
+            [date(2024, 6, 30), date(2024, 7, 7), date(2024, 7, 14)],
+            None,
+        ),  # Past Dates Only
+        (
+            date(2024, 7, 7),
+            [date(2024, 6, 30), date(2024, 7, 21), date(2024, 8, 4)],
+            date(2024, 7, 21),
+        ),  # Future Date
+    ],
+)
+def test_get_next_preaching_date(reference_date, preaching_dates, expected):
     # Arrange
-    reference_date = date(2024, 7, 7)
     person = Person(
         name="TestName",
         roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
         blockout_dates=[],
-        preaching_dates=p_dates,
+        preaching_dates=preaching_dates,
         on_leave=False,
     )
 
@@ -53,59 +72,4 @@ def test_get_next_preaching_date_with_no_dates(p_dates):
     next_preaching_date = person.get_next_preaching_date(reference_date=reference_date)
 
     # Assert
-    assert next_preaching_date is None
-
-
-def test_get_next_preaching_date_with_past_dates_only():
-    # Arrange
-    reference_date = date(2024, 7, 21)
-    person = Person(
-        name="TestName",
-        roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
-        blockout_dates=[],
-        preaching_dates=[date(2024, 6, 30), date(2024, 7, 7), date(2024, 7, 14)],
-        on_leave=False,
-    )
-
-    # Act
-    next_preaching_date = person.get_next_preaching_date(reference_date=reference_date)
-
-    # Assert
-    assert next_preaching_date is None
-
-
-def test_get_next_preaching_date_when_same_date():
-    # Arrange
-    reference_date = date(2024, 7, 7)
-    person = Person(
-        name="TestName",
-        roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
-        blockout_dates=[],
-        preaching_dates=[date(2024, 6, 30), reference_date, date(2024, 7, 14)],
-        on_leave=False,
-    )
-
-    # Act
-    next_preaching_date = person.get_next_preaching_date(reference_date=reference_date)
-
-    # Assert
-    assert next_preaching_date == reference_date
-
-
-def test_get_next_preaching_date_when_future_date():
-    # Arrange
-    reference_date = date(2024, 7, 7)
-    next_date = date(2024, 7, 21)
-    person = Person(
-        name="TestName",
-        roles=[Role.WORSHIPLEADER, Role.ACOUSTIC, Role.LYRICS],
-        blockout_dates=[],
-        preaching_dates=[date(2024, 6, 30), next_date, date(2024, 8, 4)],
-        on_leave=False,
-    )
-
-    # Act
-    next_preaching_date = person.get_next_preaching_date(reference_date=reference_date)
-
-    # Assert
-    assert next_preaching_date == next_date
+    assert next_preaching_date == expected

--- a/ui/application.py
+++ b/ui/application.py
@@ -1,58 +1,52 @@
 # Standard Library Imports
 import logging
-from typing import List
 
 # Third-Party Imports
 import customtkinter
 
 # Local Imports
 from schedule_builder.helpers.file_exporter import FileExporter
-from schedule_builder.models.person import Person
-from schedule_builder.models.preacher import Preacher
 from ui.ui_manager import UIManager
 from ui.ui_schedule_handler import UIScheduleHandler
 
 
 class App(customtkinter.CTk):
     """
-    A GUI application for scheduling team members and preachers.
+    The main GUI application for building and managing a team schedule.
 
-    Provides functionality for generating schedules, managing team assignments,
-    and exporting files.
+    This class acts as the entry point for the graphical interface and coordinates the
+    application's core components, such as scheduling logic, file export, and UI management.
 
     Attributes:
-        file_exporter (FileExporter): Handles file export operations.
-        ui_schedule_handler (UIScheduleHandler): Manages scheduling logic.
-        ui_manager (UIManager): Manages the user interface and interactions.
+        file_exporter (FileExporter): Responsible for handling file export operations.
+        schedule_handler (UIScheduleHandler): Encapsulates the scheduling logic and data.
+        ui_manager (UIManager): Manages the layout and interaction of UI components.
     """
 
     def __init__(
-        self, team: List[Person], preachers: List[Preacher], rotation: List[str]
+        self,
+        file_exporter: FileExporter,
+        schedule_handler: UIScheduleHandler,
+        ui_manager: UIManager,
     ):
         """
-        Initializes the application with a team of members, preachers, and a worship leader rotation.
+        Initializes the App with injected core components.
 
         Args:
-            team (List[Person]): A list of team members who can be assigned to roles in the schedule.
-            preachers (List[Preacher]): A list of preachers who can be scheduled for preaching duties.
-            rotation (List[str]): A list of worship leader names in priority order for scheduling.
+            file_exporter (FileExporter): An instance responsible for exporting schedule data to files.
+            schedule_handler (UIScheduleHandler): The scheduling logic and data handler.
+            ui_manager (UIManager): The user interface manager that sets up and controls UI behavior.
         """
         super().__init__()
         self.logger = logging.getLogger(__name__)
+        self.file_exporter = file_exporter
+        self.schedule_handler = schedule_handler
+        self.ui_manager = ui_manager
+        self.ui_manager.app = self
 
-        # Setup dependencies
-        self.file_exporter = FileExporter()
-        self.ui_schedule_handler = UIScheduleHandler(
-            team=team,
-            preachers=preachers,
-            rotation=rotation,
-            file_exporter=self.file_exporter,
-        )
-        self.ui_manager = UIManager(
-            app=self,
-            schedule_handler=self.ui_schedule_handler,
-            title="Schedule Builder",
-        )
-
-        # Setup UI
+    def start(self):
+        """
+        Starts the application by setting up the UI and entering the main event loop.
+        """
         self.ui_manager.setup()
+        self.mainloop()


### PR DESCRIPTION
- Refactor App class to inject object dependencies rather than creating them in the init
- Convert Person to data class
- Convert Preacher to data class
- Apply more pytest parameterization for Person and Schedule tests